### PR TITLE
chore: avoid subtracting usize leading to overflow

### DIFF
--- a/protosocket-connection/src/connection.rs
+++ b/protosocket-connection/src/connection.rs
@@ -239,7 +239,7 @@ where
 
     pub fn read_inbound_messages_into_read_queue(&mut self) -> Result<bool, std::io::Error> {
         while self.receive_buffer_start_offset < self.receive_buffer_slice_end {
-            if self.inbound_messages.len() >= self.inbound_messages.capacity() {
+            if self.inbound_messages.capacity() == self.inbound_messages.len()  {
                 // can't accept any more inbound messages right now
                 log::debug!("inbound message queue is draining too slowly");
                 break;

--- a/protosocket-connection/src/connection.rs
+++ b/protosocket-connection/src/connection.rs
@@ -239,7 +239,7 @@ where
 
     pub fn read_inbound_messages_into_read_queue(&mut self) -> Result<bool, std::io::Error> {
         while self.receive_buffer_start_offset < self.receive_buffer_slice_end {
-            if self.inbound_messages.capacity() == self.inbound_messages.len()  {
+            if self.inbound_messages.capacity() == self.inbound_messages.len() {
                 // can't accept any more inbound messages right now
                 log::debug!("inbound message queue is draining too slowly");
                 break;

--- a/protosocket-connection/src/connection.rs
+++ b/protosocket-connection/src/connection.rs
@@ -239,7 +239,7 @@ where
 
     pub fn read_inbound_messages_into_read_queue(&mut self) -> Result<bool, std::io::Error> {
         while self.receive_buffer_start_offset < self.receive_buffer_slice_end {
-            if 0 == self.inbound_messages.len() - self.inbound_messages.capacity() {
+            if self.inbound_messages.len() >= self.inbound_messages.capacity() {
                 // can't accept any more inbound messages right now
                 log::debug!("inbound message queue is draining too slowly");
                 break;


### PR DESCRIPTION
I am not exactly sure why the `len()` is greater than the `capacity()` when I start the telnet example, but I see a panic when running it and sending commands through telnet:

```
thread 'tokio-runtime-worker' panicked at /Users/pratik/sandbox/protosocket/protosocket-connection/src/connection.rs:243:21:
attempt to subtract with overflow
```