### PR TITLE
feat: making is_alive public from RpcClient

### DIFF
--- a/example-proto/src/client.rs
+++ b/example-proto/src/client.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-use futures::{stream::FuturesUnordered, task::SpawnExt, FutureExt, StreamExt};
+use futures::{stream::FuturesUnordered, task::SpawnExt, StreamExt};
 use messages::{EchoRequest, EchoResponseKind, Request, Response, ResponseBehavior};
 use protosocket_rpc::{client::RpcClient, ProtosocketControlCode};
 use tokio::sync::Semaphore;

--- a/example-proto/src/client.rs
+++ b/example-proto/src/client.rs
@@ -161,7 +161,8 @@ async fn generate_traffic(
                         let response = completion.await.expect("response must be successful");
                         handle_response(response, metrics_count, metrics_latency);
                         drop(permit);
-                    }).expect("can spawn");
+                    })
+                    .expect("can spawn");
                 }
                 Err(e) => {
                     log::error!("send should work: {e:?}");
@@ -197,7 +198,8 @@ async fn generate_traffic(
                             );
                         }
                         drop(permit);
-                    }).expect("can spawn");
+                    })
+                    .expect("can spawn");
                 }
                 Err(e) => {
                     log::error!("send should work: {e:?}");
@@ -256,10 +258,7 @@ fn handle_stream_response(
             let place = places - char_response.sequence as u32;
             let column = (request_id / 10u64.pow(place)) % 10;
 
-            assert_eq!(
-                Ok(column),
-                char_response.message.parse()
-            );
+            assert_eq!(Ok(column), char_response.message.parse());
 
             if place == places - 1 {
                 let latency = SystemTime::now()

--- a/protosocket-rpc/src/client/rpc_client.rs
+++ b/protosocket-rpc/src/client/rpc_client.rs
@@ -42,6 +42,11 @@ where
         }
     }
 
+    pub fn is_alive(&self) -> bool {
+        self.is_alive.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+
     /// Send a server-streaming rpc to the server.
     ///
     /// This function only sends the request. You must consume the completion stream to get the response.

--- a/protosocket-rpc/src/client/rpc_client.rs
+++ b/protosocket-rpc/src/client/rpc_client.rs
@@ -42,10 +42,12 @@ where
         }
     }
 
+    /// Check if the client is still connected to the server.
+    ///
+    /// We need this is_alive flag to be public so that the client can check if the connection is still alive.
     pub fn is_alive(&self) -> bool {
         self.is_alive.load(std::sync::atomic::Ordering::Relaxed)
     }
-
 
     /// Send a server-streaming rpc to the server.
     ///

--- a/protosocket-rpc/src/client/rpc_client.rs
+++ b/protosocket-rpc/src/client/rpc_client.rs
@@ -42,9 +42,9 @@ where
         }
     }
 
-    /// Check if the client is still connected to the server.
-    ///
-    /// We need this is_alive flag to be public so that the client can check if the connection is still alive.
+    /// Checking this before using the client does not guarantee that the client is still alive when you send  
+    /// your message. It may be useful for connection pool implementations - for example, [bb8::ManageConnection](https://github.com/djc/bb8/blob/09a043c001b3c15514d9f03991cfc87f7118a000/bb8/src/api.rs#L383-L384)'s  
+    /// is_valid and has_broken could be bound to this function to help the pool cycle out broken connections.  
     pub fn is_alive(&self) -> bool {
         self.is_alive.load(std::sync::atomic::Ordering::Relaxed)
     }


### PR DESCRIPTION
## Why
Client needs to know if Server has been disconnected in order to re-establish the connection. Without public is_alive(), we will not be able to do it.