### PR TITLE
drop safe client completions

### DIFF
--- a/protosocket-rpc/src/client/reactor/completion_unary.rs
+++ b/protosocket-rpc/src/client/reactor/completion_unary.rs
@@ -11,41 +11,47 @@ use crate::Message;
 
 /// A completion for a unary RPC.
 #[derive(Debug)]
-pub struct UnaryCompletion<Response>
+pub struct UnaryCompletion<Response, Request>
 where
     Response: Message,
+    Request: Message,
 {
     completion: oneshot::Receiver<crate::Result<Response>>,
-    _completion_guard: CompletionGuard<Response>,
+    completion_guard: CompletionGuard<Response, Request>,
 }
 
-impl<Response> UnaryCompletion<Response>
+impl<Response, Request> UnaryCompletion<Response, Request>
 where
     Response: Message,
+    Request: Message,
 {
     pub(crate) fn new(
         completion: oneshot::Receiver<crate::Result<Response>>,
-        completion_guard: CompletionGuard<Response>,
+        completion_guard: CompletionGuard<Response, Request>,
     ) -> Self {
         Self {
             completion,
-            _completion_guard: completion_guard,
+            completion_guard,
         }
     }
 }
 
-impl<Response> Future for UnaryCompletion<Response>
+impl<Response, Request> Future for UnaryCompletion<Response, Request>
 where
     Response: Message,
+    Request: Message,
 {
     type Output = crate::Result<Response>;
 
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
         match pin!(&mut self.completion).poll(context) {
-            Poll::Ready(result) => match result {
-                Ok(done) => Poll::Ready(done),
-                Err(_cancelled) => Poll::Ready(Err(crate::Error::CancelledRemotely)),
-            },
+            Poll::Ready(result) => {
+                self.completion_guard.set_closed();
+                match result {
+                    Ok(done) => Poll::Ready(done),
+                    Err(_cancelled) => Poll::Ready(Err(crate::Error::CancelledRemotely)),
+                }
+            }
             Poll::Pending => Poll::Pending,
         }
     }

--- a/protosocket-rpc/src/client/rpc_client.rs
+++ b/protosocket-rpc/src/client/rpc_client.rs
@@ -56,7 +56,7 @@ where
     pub async fn send_streaming(
         &self,
         request: Request,
-    ) -> crate::Result<StreamingCompletion<Response>> {
+    ) -> crate::Result<StreamingCompletion<Response, Request>> {
         let (sender, completion) = mpsc::unbounded_channel();
         let completion_guard = self
             .send_message(Completion::RemoteStreaming(sender), request)
@@ -71,7 +71,10 @@ where
     ///
     /// This function only sends the request. You must await the completion to get the response.
     #[must_use = "You must await the completion to get the response. If you drop the completion, the request will be cancelled."]
-    pub async fn send_unary(&self, request: Request) -> crate::Result<UnaryCompletion<Response>> {
+    pub async fn send_unary(
+        &self,
+        request: Request,
+    ) -> crate::Result<UnaryCompletion<Response, Request>> {
         let (completor, completion) = oneshot::channel();
         let completion_guard = self
             .send_message(Completion::Unary(completor), request)
@@ -86,18 +89,117 @@ where
         &self,
         completion: Completion<Response>,
         request: Request,
-    ) -> crate::Result<CompletionGuard<Response>> {
+    ) -> crate::Result<CompletionGuard<Response, Request>> {
         if !self.is_alive.load(std::sync::atomic::Ordering::Relaxed) {
             // early-out if the connection is closed
             return Err(crate::Error::ConnectionIsClosed);
         }
-        let completion_guard = self
-            .in_flight_submission
-            .register_completion(request.message_id(), completion);
+        let completion_guard = self.in_flight_submission.register_completion(
+            request.message_id(),
+            completion,
+            self.submission_queue.clone(),
+        );
         self.submission_queue
             .send(request)
             .await
             .map_err(|_e| crate::Error::ConnectionIsClosed)
             .map(|_| completion_guard)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::future::Future;
+    use std::pin::pin;
+    use std::task::Context;
+    use std::task::Poll;
+
+    use futures::task::noop_waker_ref;
+
+    use crate::client::reactor::completion_reactor::DoNothingMessageHandler;
+    use crate::client::reactor::completion_reactor::RpcCompletionReactor;
+    use crate::Message;
+
+    use super::RpcClient;
+
+    impl Message for u64 {
+        fn message_id(&self) -> u64 {
+            *self & 0xffffffff
+        }
+
+        fn control_code(&self) -> crate::ProtosocketControlCode {
+            match *self >> 32 {
+                0 => crate::ProtosocketControlCode::Normal,
+                1 => crate::ProtosocketControlCode::Cancel,
+                2 => crate::ProtosocketControlCode::End,
+                _ => unreachable!("invalid control code"),
+            }
+        }
+
+        fn set_message_id(&mut self, message_id: u64) {
+            *self = (*self & 0xf00000000) | message_id;
+        }
+
+        fn cancelled(message_id: u64) -> Self {
+            (1_u64 << 32) | message_id
+        }
+
+        fn ended(message_id: u64) -> Self {
+            (2 << 32) | message_id
+        }
+    }
+
+    fn drive_future<F: Future>(f: F) -> F::Output {
+        let mut f = pin!(f);
+        loop {
+            let next = f.as_mut().poll(&mut Context::from_waker(noop_waker_ref()));
+            if let Poll::Ready(result) = next {
+                break result;
+            }
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn get_client() -> (
+        tokio::sync::mpsc::Receiver<u64>,
+        RpcClient<u64, u64>,
+        RpcCompletionReactor<u64, DoNothingMessageHandler<u64>>,
+    ) {
+        let (sender, remote_end) = tokio::sync::mpsc::channel::<u64>(10);
+        let rpc_reactor = RpcCompletionReactor::<u64, _>::new(DoNothingMessageHandler::default());
+        let client = RpcClient::new(sender, &rpc_reactor);
+        (remote_end, client, rpc_reactor)
+    }
+
+    #[test]
+    fn unary_drop_cancel() {
+        let (mut remote_end, client, _reactor) = get_client();
+
+        let response = drive_future(client.send_unary(4)).expect("can send");
+        assert_eq!(4, remote_end.blocking_recv().expect("a request is sent"));
+        assert!(remote_end.is_empty(), "no more messages yet");
+
+        drop(response);
+
+        assert_eq!(
+            (1 << 32) + 4,
+            remote_end.blocking_recv().expect("a cancel is sent")
+        );
+    }
+
+    #[test]
+    fn streaming_drop_cancel() {
+        let (mut remote_end, client, _reactor) = get_client();
+
+        let response = drive_future(client.send_streaming(4)).expect("can send");
+        assert_eq!(4, remote_end.blocking_recv().expect("a request is sent"));
+        assert!(remote_end.is_empty(), "no more messages yet");
+
+        drop(response);
+
+        assert_eq!(
+            (1 << 32) + 4,
+            remote_end.blocking_recv().expect("a cancel is sent")
+        );
     }
 }


### PR DESCRIPTION
client completions were not sending cancellation messages when the completion was dropped. The rpc model has cancellation, and the server has tests to ensure it considers them, but the rpc client was not handled.

Now when a streaming or unary rpc is dropped without being gracefully completed, a cancellation control code will be sent.