### PR TITLE
chore: pass socket address into protosocket servers

### DIFF
--- a/example-telnet/src/main.rs
+++ b/example-telnet/src/main.rs
@@ -47,6 +47,7 @@ impl ServerConnector for ServerContext {
         optional_outbound: tokio::sync::mpsc::Sender<
             <<Self::Bindings as ConnectionBindings>::Serializer as Serializer>::Message,
         >,
+        _address: std::net::SocketAddr,
     ) -> <Self::Bindings as ConnectionBindings>::Reactor {
         StringReactor {
             outbound: optional_outbound,

--- a/protosocket-server/src/connection_server.rs
+++ b/protosocket-server/src/connection_server.rs
@@ -22,7 +22,7 @@ pub trait ServerConnector: Unpin {
         optional_outbound: mpsc::Sender<
             <<Self::Bindings as ConnectionBindings>::Serializer as Serializer>::Message,
         >,
-        address: SocketAddr
+        address: SocketAddr,
     ) -> <Self::Bindings as ConnectionBindings>::Reactor;
 
     fn maximum_message_length(&self) -> usize {

--- a/protosocket-server/src/connection_server.rs
+++ b/protosocket-server/src/connection_server.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 use std::io::Error;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Context;
@@ -21,6 +22,7 @@ pub trait ServerConnector: Unpin {
         optional_outbound: mpsc::Sender<
             <<Self::Bindings as ConnectionBindings>::Serializer as Serializer>::Message,
         >,
+        address: SocketAddr
     ) -> <Self::Bindings as ConnectionBindings>::Reactor;
 
     fn maximum_message_length(&self) -> usize {
@@ -108,7 +110,7 @@ impl<Connector: ServerConnector> Future for ProtosocketServer<Connector> {
                             mpsc::channel(self.max_queued_outbound_messages);
                         let reactor = self
                             .connector
-                            .new_reactor(outbound_submission_queue.clone());
+                            .new_reactor(outbound_submission_queue.clone(), address);
                         let stream = self.connector.connect(stream);
                         let connection: Connection<Connector::Bindings> = Connection::new(
                             stream,


### PR DESCRIPTION
Servers might care to use this information, so let's give it to them.