### PR TITLE
allow configuring socket options for raw protosocket servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,6 +853,7 @@ dependencies = [
  "futures",
  "log",
  "protosocket",
+ "socket2 0.6.0",
  "thiserror",
  "tokio",
 ]

--- a/example-telnet/src/main.rs
+++ b/example-telnet/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 use protosocket::{
     ConnectionBindings, DeserializeError, Deserializer, MessageReactor, ReactorStatus, Serializer,
 };
-use protosocket_server::{ProtosocketServer, ProtosocketServerConfig, ServerConnector};
+use protosocket_server::{ProtosocketServerConfig, ServerConnector};
 
 #[allow(clippy::expect_used)]
 #[tokio::main]
@@ -15,13 +15,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
     let server_context = ServerContext::default();
-    let server = ProtosocketServer::new(
-        "127.0.0.1:9000".parse()?,
-        tokio::runtime::Handle::current(),
-        server_context,
-        ProtosocketServerConfig::default(),
-    )
-    .await?;
+    let config = ProtosocketServerConfig::default();
+    let server = config
+        .bind_tcp(
+            "127.0.0.1:9000".parse()?,
+            server_context,
+            tokio::runtime::Handle::current(),
+        )
+        .await?;
 
     tokio::spawn(server).await??;
     Ok(())

--- a/example-telnet/src/main.rs
+++ b/example-telnet/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 use protosocket::{
     ConnectionBindings, DeserializeError, Deserializer, MessageReactor, ReactorStatus, Serializer,
 };
-use protosocket_server::{ProtosocketServer, ServerConnector};
+use protosocket_server::{ProtosocketServer, ProtosocketServerConfig, ServerConnector};
 
 #[allow(clippy::expect_used)]
 #[tokio::main]
@@ -19,6 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "127.0.0.1:9000".parse()?,
         tokio::runtime::Handle::current(),
         server_context,
+        ProtosocketServerConfig::default(),
     )
     .await?;
 

--- a/protosocket-server/Cargo.toml
+++ b/protosocket-server/Cargo.toml
@@ -16,5 +16,6 @@ protosocket             = { workspace = true }
 bytes                   = { workspace = true }
 futures                 = { workspace = true }
 log                     = { workspace = true }
+socket2                 = { workspace = true, features = ["all"] }
 thiserror               = { workspace = true }
 tokio                   = { workspace = true }

--- a/protosocket-server/src/error.rs
+++ b/protosocket-server/src/error.rs
@@ -13,3 +13,9 @@ pub enum Error {
     #[error("Requested resource was dead: ({0})")]
     Dead(&'static str),
 }
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Self::IoFailure(Arc::new(e))
+    }
+}

--- a/protosocket-server/src/lib.rs
+++ b/protosocket-server/src/lib.rs
@@ -7,6 +7,8 @@ pub(crate) mod connection_server;
 pub(crate) mod error;
 
 pub use connection_server::ProtosocketServer;
+pub use connection_server::ProtosocketServerConfig;
+pub use connection_server::ProtosocketSocketConfig;
 pub use connection_server::ServerConnector;
 pub use error::Error;
 pub use error::Result;


### PR DESCRIPTION
It'd be useful to be able to configure the socket with these when writing a server. I also included the three existing configurable fields, since I was adding a config parameter anyway.