### PR TITLE
fix: handle noncontiguous send buffers

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,7 +2,9 @@ name: PR
 
 on:
   pull_request:
-    branches: [ main ]
+    types:
+      - opened
+      - reopened
 
 env:
   CARGO_TERM_COLOR: always

--- a/protosocket-connection/src/connection.rs
+++ b/protosocket-connection/src/connection.rs
@@ -380,19 +380,19 @@ impl<
 
                 // Use chunks_vectored rather than chunk() to correctly handle
                 // Buf implementations that aren't backed by a single contiguous slice.
-                let mut buffers = vec![IoSlice::new(&[]); UIO_MAXIOV];
+                let mut stack_buffers = [IoSlice::new(&[]); UIO_MAXIOV];
                 let mut filled = 0;
                 for buf in self.send_buffer.iter() {
                     if UIO_MAXIOV <= filled {
                         break;
                     }
-                    let n = buf.chunks_vectored(&mut buffers[filled..]);
+                    let n = buf.chunks_vectored(&mut stack_buffers[filled..]);
                     if n == 0 {
                         break;
                     }
                     filled += n;
                 }
-                buffers.truncate(filled);
+                let buffers = &stack_buffers[..filled];
 
                 #[cfg(feature = "tracing")]
                 let span = tracing::span!(tracing::Level::INFO, "writing", buffers = buffers.len());

--- a/protosocket-connection/src/connection.rs
+++ b/protosocket-connection/src/connection.rs
@@ -378,12 +378,21 @@ impl<
                 // 16 is the lowest I've seen mention of, and I've seen 1024 more commonly.
                 const UIO_MAXIOV: usize = 256;
 
-                let buffers: Vec<IoSlice> = self
-                    .send_buffer
-                    .iter()
-                    .take(UIO_MAXIOV)
-                    .map(|v| IoSlice::new(v.chunk()))
-                    .collect();
+                // Use chunks_vectored rather than chunk() to correctly handle
+                // Buf implementations that aren't backed by a single contiguous slice.
+                let mut buffers = vec![IoSlice::new(&[]); UIO_MAXIOV];
+                let mut filled = 0;
+                for buf in self.send_buffer.iter() {
+                    if UIO_MAXIOV <= filled {
+                        break;
+                    }
+                    let n = buf.chunks_vectored(&mut buffers[filled..]);
+                    if n == 0 {
+                        break;
+                    }
+                    filled += n;
+                }
+                buffers.truncate(filled);
 
                 #[cfg(feature = "tracing")]
                 let span = tracing::span!(tracing::Level::INFO, "writing", buffers = buffers.len());

--- a/protosocket-connection/src/connection.rs
+++ b/protosocket-connection/src/connection.rs
@@ -398,7 +398,7 @@ impl<
                 let span = tracing::span!(tracing::Level::INFO, "writing", buffers = buffers.len());
                 #[cfg(feature = "tracing")]
                 let span_guard = span.enter();
-                let poll = pin!(&mut self.stream).poll_write_vectored(context, &buffers);
+                let poll = pin!(&mut self.stream).poll_write_vectored(context, buffers);
                 #[cfg(feature = "tracing")]
                 drop(span_guard);
                 match poll {
@@ -432,7 +432,7 @@ impl<
                             "error while writing to tcp stream: {err:?}, buffers: {}, {}b: {:?}",
                             buffers.len(),
                             buffers.iter().map(|b| b.len()).sum::<usize>(),
-                            buffers.into_iter().map(|b| b.len()).collect::<Vec<_>>()
+                            buffers.iter().map(|b| b.len()).collect::<Vec<_>>()
                         );
                         Err(err)
                     }


### PR DESCRIPTION
Ran into this when trying to put together a zero-copy encoder for RESP - you really kinda have to use a noncontiguous implementation of Buf for that to work with protosocket.

The issue is that if a buffer was backed by noncontiguous slices, `.chunk()` will usually only return the _first_ section.

So we'll only partially write that buffer out to the wire before moving onto the next, and then when we come back to do our `advance` bookkeeping, we get totally off-track.

I'm not really entirely sure this properly handles things either... but it's at least closer for well-behaving implementors of `chunks_vectored`, I think?